### PR TITLE
Fix generation of wares in market

### DIFF
--- a/src/Core/GameMaster.cpp
+++ b/src/Core/GameMaster.cpp
@@ -257,7 +257,7 @@ void GameMaster::doQuest(int questId)
 void GameMaster::newWeek()
 {
 	qDebug() << "New week has begun.";
-	for (QList <const Item *> &i : waresInCities_.values())
+	for (QList <const Item *> &i : waresInCities_)
 		generateWaresForMarket(i);
 
 	for (int city : questsInCities_.keys()) {


### PR DESCRIPTION
Cause: QMap.values() passes its result by copy, not by reference.
